### PR TITLE
using eloquent's magic instead of datetime fields

### DIFF
--- a/app/database/migrations/2013_12_03_000000_CreateAccountTable.php
+++ b/app/database/migrations/2013_12_03_000000_CreateAccountTable.php
@@ -14,9 +14,8 @@ extends Migration
       $table->increments("id");
       $table->string("email");
       $table->string("password");
-      $table->dateTime("created_at");
-      $table->dateTime("updated_at");
-      $table->dateTime("deleted_at");
+      $table->timestamps();
+      $table->softDeletes();
     });
   }
 

--- a/app/database/migrations/2013_12_03_000000_CreateCategoryTable.php
+++ b/app/database/migrations/2013_12_03_000000_CreateCategoryTable.php
@@ -13,9 +13,8 @@ extends Migration
       
       $table->increments("id");
       $table->string("name");
-      $table->dateTime("created_at");
-      $table->dateTime("updated_at");
-      $table->dateTime("deleted_at");
+      $table->timestamps();
+      $table->softDeletes();
     });
   }
 

--- a/app/database/migrations/2013_12_03_000000_CreateOrderItemTable.php
+++ b/app/database/migrations/2013_12_03_000000_CreateOrderItemTable.php
@@ -16,9 +16,8 @@ extends Migration
       $table->integer("product_id");
       $table->integer("quantity");
       $table->float("price");
-      $table->dateTime("created_at");
-      $table->dateTime("updated_at");
-      $table->dateTime("deleted_at");
+      $table->timestamps();
+      $table->softDeletes();
     });
   }
 

--- a/app/database/migrations/2013_12_03_000000_CreateOrderTable.php
+++ b/app/database/migrations/2013_12_03_000000_CreateOrderTable.php
@@ -13,9 +13,8 @@ extends Migration
       
       $table->increments("id");
       $table->integer("account_id");
-      $table->dateTime("created_at");
-      $table->dateTime("updated_at");
-      $table->dateTime("deleted_at");
+      $table->timestamps();
+      $table->softDeletes();
     });
   }
 

--- a/app/database/migrations/2013_12_03_000000_CreateProductTable.php
+++ b/app/database/migrations/2013_12_03_000000_CreateProductTable.php
@@ -16,9 +16,8 @@ extends Migration
       $table->string("name");
       $table->integer("stock");
       $table->float("price");
-      $table->dateTime("created_at");
-      $table->dateTime("updated_at");
-      $table->dateTime("deleted_at");
+      $table->timestamps();
+      $table->softDeletes();
     });
   }
 


### PR DESCRIPTION
Hey @formativ,

Great tutorial on using L4 to create a simple e-commerce site. While reading I thought why you didn't use Eloquent's "magic" methods instead of datetime fields (updated_at, created_at, deleted_at). Eloquent has `$table->timestamps();`and `$table->softDeletes` that should be more "universal". How about using them?

Cheers!
